### PR TITLE
DTO 조회로 성능 개선하기

### DIFF
--- a/src/main/generated/com/peeerr/climbing/dto/post/response/QPostResponse.java
+++ b/src/main/generated/com/peeerr/climbing/dto/post/response/QPostResponse.java
@@ -1,0 +1,21 @@
+package com.peeerr.climbing.dto.post.response;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.ConstructorExpression;
+import javax.annotation.processing.Generated;
+
+/**
+ * com.peeerr.climbing.dto.post.response.QPostResponse is a Querydsl Projection type for PostResponse
+ */
+@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
+public class QPostResponse extends ConstructorExpression<PostResponse> {
+
+    private static final long serialVersionUID = -1231495484L;
+
+    public QPostResponse(com.querydsl.core.types.Expression<Long> postId, com.querydsl.core.types.Expression<String> title, com.querydsl.core.types.Expression<String> content, com.querydsl.core.types.Expression<String> categoryName, com.querydsl.core.types.Expression<String> writer, com.querydsl.core.types.Expression<java.time.LocalDateTime> createDate, com.querydsl.core.types.Expression<java.time.LocalDateTime> modifyDate) {
+        super(PostResponse.class, new Class<?>[]{long.class, String.class, String.class, String.class, String.class, java.time.LocalDateTime.class, java.time.LocalDateTime.class}, postId, title, content, categoryName, writer, createDate, modifyDate);
+    }
+
+}
+

--- a/src/main/java/com/peeerr/climbing/domain/post/CustomPostRepository.java
+++ b/src/main/java/com/peeerr/climbing/domain/post/CustomPostRepository.java
@@ -1,6 +1,7 @@
 package com.peeerr.climbing.domain.post;
 
 import com.peeerr.climbing.dto.post.request.PostSearchCondition;
+import com.peeerr.climbing.dto.post.response.PostResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,7 +9,7 @@ import java.util.Optional;
 
 public interface CustomPostRepository {
 
-    Page<Post> findPostsFilteredByCategoryIdAndSearchWord(Long categoryId, PostSearchCondition condition, Pageable pageable);
+    Page<PostResponse> findPostsFilteredByCategoryIdAndSearchWord(Long categoryId, PostSearchCondition condition, Pageable pageable);
 
     Optional<Post> findPostById(Long postId);
 

--- a/src/main/java/com/peeerr/climbing/domain/post/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/peeerr/climbing/domain/post/CustomPostRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.peeerr.climbing.domain.post;
 
 import com.peeerr.climbing.dto.post.request.PostSearchCondition;
+import com.peeerr.climbing.dto.post.response.PostResponse;
+import com.peeerr.climbing.dto.post.response.QPostResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -28,11 +30,19 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     }
 
     @Override
-    public Page<Post> findPostsFilteredByCategoryIdAndSearchWord(Long categoryId, PostSearchCondition condition, Pageable pageable) {
-        List<Post> posts = queryFactory
-                .selectFrom(post)
-                .join(post.category, category).fetchJoin()
-                .join(post.member, member).fetchJoin()
+    public Page<PostResponse> findPostsFilteredByCategoryIdAndSearchWord(Long categoryId, PostSearchCondition condition, Pageable pageable) {
+        List<PostResponse> posts = queryFactory
+                .select(new QPostResponse(
+                        post.id,
+                        post.title,
+                        post.content,
+                        post.category.categoryName,
+                        post.member.username,
+                        post.createDate,
+                        post.modifyDate))
+                .from(post)
+                .join(post.category, category)
+                .join(post.member, member)
                 .where(categoryEq(categoryId), titleContains(condition.getTitle()), contentContains(condition.getContent()))
                 .orderBy(post.createDate.desc())
                 .offset(pageable.getOffset())

--- a/src/main/java/com/peeerr/climbing/dto/post/response/PostResponse.java
+++ b/src/main/java/com/peeerr/climbing/dto/post/response/PostResponse.java
@@ -1,13 +1,13 @@
 package com.peeerr.climbing.dto.post.response;
 
 import com.peeerr.climbing.domain.post.Post;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class PostResponse {
 
@@ -28,6 +28,17 @@ public class PostResponse {
                 post.getMember().getUsername(),
                 post.getCreateDate(),
                 post.getModifyDate());
+    }
+
+    @QueryProjection
+    public PostResponse(Long postId, String title, String content, String categoryName, String writer, LocalDateTime createDate, LocalDateTime modifyDate) {
+        this.postId = postId;
+        this.title = title;
+        this.content = content;
+        this.categoryName = categoryName;
+        this.writer = writer;
+        this.createDate = createDate;
+        this.modifyDate = modifyDate;
     }
 
 }

--- a/src/main/java/com/peeerr/climbing/service/PostService.java
+++ b/src/main/java/com/peeerr/climbing/service/PostService.java
@@ -15,13 +15,9 @@ import com.peeerr.climbing.exception.ex.EntityNotFoundException;
 import com.peeerr.climbing.exception.ex.UnauthorizedAccessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -32,11 +28,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public Page<PostResponse> getPostsFilteredByCategoryIdAndSearchWord(Long categoryId, PostSearchCondition condition, Pageable pageable) {
-        List<PostResponse> posts = postRepository.findPostsFilteredByCategoryIdAndSearchWord(categoryId, condition, pageable).stream()
-                .map(PostResponse::from)
-                .collect(Collectors.toList());
-
-        return new PageImpl<>(posts, pageable, posts.size());
+        return postRepository.findPostsFilteredByCategoryIdAndSearchWord(categoryId, condition, pageable);
     }
 
     /*

--- a/src/test/java/com/peeerr/climbing/controller/LikeControllerTest.java
+++ b/src/test/java/com/peeerr/climbing/controller/LikeControllerTest.java
@@ -38,7 +38,7 @@ class LikeControllerTest {
         given(likeService.getLikeCount(postId)).willReturn(likeCount);
 
         //when
-        ResultActions result = mvc.perform(get("/api/likes/{postId}", postId));
+        ResultActions result = mvc.perform(get("/api/likes/{postId}/count", postId));
 
         //then
         result


### PR DESCRIPTION
엔티티 조회가 아닌 DTO 조회로 리팩토링

* 기존에는 필요 없는 컬럼까지 모두 조회 -> 필요한 컬럼만 조회
* 서비스 로직에서 DTO로 변환하는 작업 제거