### PR TITLE
파일 업로드 기능에 대한 kafka consumer 예외 처리

### DIFF
--- a/src/main/java/com/peeerr/climbing/config/FileUploadErrorHandler.java
+++ b/src/main/java/com/peeerr/climbing/config/FileUploadErrorHandler.java
@@ -1,0 +1,69 @@
+package com.peeerr.climbing.config;
+
+import com.peeerr.climbing.constant.FileUploadState;
+import com.peeerr.climbing.dto.FileChunkMessage;
+import com.peeerr.climbing.service.FileUploadMessagingService;
+import com.peeerr.climbing.service.S3FileUploadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class FileUploadErrorHandler {
+
+    private final FileUploadMessagingService messagingService;
+    private final S3FileUploadService s3FileUploadService;
+
+    public void handleError(ConsumerRecord<?, ?> record, Exception exception) {
+        try {
+            FileChunkMessage message = (FileChunkMessage) record.value();
+            String fileId = message.getFileId();
+
+            log.error("File chunk processing failed. FileId: {}, ChunkIndex: {}, Error: {}",
+                    fileId, message.getChunkIndex(), exception.getMessage());
+
+            handleFailedUpload(message);
+        } catch (Exception e) {
+            log.error("Error occurred while handling failure", e);
+        }
+    }
+
+    private void handleFailedUpload(FileChunkMessage message) {
+        String fileId = message.getFileId();
+
+        try {
+            // 1. 실패 상태 업데이트
+            messagingService.sendFileStatus(fileId, FileUploadState.FAILED);
+
+            // 2. S3 리소스 정리
+            cleanupS3Resources(message);
+
+            // 3. Redis 키 정리
+            messagingService.cleanupRedisKeys(fileId);
+
+            // 4. 실패한 파일 ID 기록
+            messagingService.recordFailedFileId(fileId);
+
+        } catch (Exception e) {
+            log.error("Failed to handle upload failure for fileId: {}", fileId, e);
+        }
+    }
+
+    private void cleanupS3Resources(FileChunkMessage message) {
+        messagingService.getUploadIdFromRedis(message.getFileId())
+                .ifPresent(uploadId -> {
+                    try {
+                        s3FileUploadService.abortMultipartUpload(message, uploadId);
+                        log.info("Successfully aborted multipart upload. FileId: {}, UploadId: {}",
+                                message.getFileId(), uploadId);
+                    } catch (Exception e) {
+                        log.error("Failed to abort multipart upload. FileId: {}, UploadId: {}",
+                                message.getFileId(), uploadId, e);
+                    }
+                });
+    }
+
+}

--- a/src/main/java/com/peeerr/climbing/constant/FileUploadConstants.java
+++ b/src/main/java/com/peeerr/climbing/constant/FileUploadConstants.java
@@ -6,8 +6,10 @@ public final class FileUploadConstants {
 
     public static final String UPLOAD_STATUS_PREFIX = "upload:status:";
     public static final String UPLOAD_PARTS_PREFIX = "upload:parts:";
+    public static final String FAILED_FILES_KEY = "upload:failed:files";
 
     public static final long UPLOAD_EXPIRY = TimeUnit.HOURS.toSeconds(3); // 3 hours
+    public static final long FAILED_FILE_EXPIRY = TimeUnit.HOURS.toSeconds(1);
     public static final int CHUNK_SIZE = 5 * 1024 * 1024; // 5MB
 
 }

--- a/src/main/java/com/peeerr/climbing/service/FileUploadMessagingService.java
+++ b/src/main/java/com/peeerr/climbing/service/FileUploadMessagingService.java
@@ -1,5 +1,7 @@
 package com.peeerr.climbing.service;
 
+import static com.peeerr.climbing.constant.FileUploadConstants.FAILED_FILES_KEY;
+import static com.peeerr.climbing.constant.FileUploadConstants.FAILED_FILE_EXPIRY;
 import static com.peeerr.climbing.constant.FileUploadConstants.UPLOAD_EXPIRY;
 import static com.peeerr.climbing.constant.FileUploadConstants.UPLOAD_PARTS_PREFIX;
 import static com.peeerr.climbing.constant.FileUploadConstants.UPLOAD_STATUS_PREFIX;
@@ -15,11 +17,13 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class FileUploadMessagingService {
@@ -27,6 +31,26 @@ public class FileUploadMessagingService {
     private final RedisTemplate<String, String> redisTemplate;
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final SimpMessagingTemplate messagingTemplate;
+
+    public void recordFailedFileId(String fileId) {
+        try {
+            redisTemplate.opsForSet().add(FAILED_FILES_KEY, fileId);
+            redisTemplate.expire(FAILED_FILES_KEY, FAILED_FILE_EXPIRY, TimeUnit.SECONDS);
+            log.info("Recorded failed fileId: {}", fileId);
+        } catch (Exception e) {
+            log.error("Failed to record failed fileId: {}", fileId, e);
+        }
+    }
+
+    public boolean isFailedFileId(String fileId) {
+        try {
+            Boolean isMember = redisTemplate.opsForSet().isMember(FAILED_FILES_KEY, fileId);
+            return Boolean.TRUE.equals(isMember);
+        } catch (Exception e) {
+            log.error("Failed to check failed fileId: {}", fileId, e);
+            return false;
+        }
+    }
 
     public void saveUploadIdToRedis(String fileId, String uploadId) {
         redisTemplate.opsForValue().set(UPLOAD_STATUS_PREFIX + fileId, uploadId, UPLOAD_EXPIRY, TimeUnit.SECONDS);
@@ -37,7 +61,7 @@ public class FileUploadMessagingService {
     }
 
     public void sendFileChunkToKafka(FileChunkMessage message) {
-        kafkaTemplate.send(Topic.FILE_CHUNK, message.getFileId(), message);
+        kafkaTemplate.send(Topic.FILE_CHUNK, message);
     }
 
     public void sendFileStatus(String fileId, FileUploadState state) {
@@ -54,6 +78,12 @@ public class FileUploadMessagingService {
         String key = UPLOAD_PARTS_PREFIX + fileId;
         redisTemplate.opsForHash().put(key, String.valueOf(partNumber), partETag.getETag());
         redisTemplate.expire(key, UPLOAD_EXPIRY, TimeUnit.SECONDS);
+    }
+
+    public boolean isUploadComplete(String fileId, int totalParts) {
+        String key = UPLOAD_PARTS_PREFIX + fileId;
+        Long uploadedParts = redisTemplate.opsForHash().size(key);
+        return uploadedParts.intValue() == totalParts;
     }
 
     public List<PartETag> getPartETagsFromRedis(String fileId, int totalParts) {


### PR DESCRIPTION
### 현재 consumer에서 청크 처리 실패 시에 대한 예외 처리가 없음

### 아래와 같은 시나리오로 예외 처리 추가

1. `FileChunkConsumer`에서 예외 발생

2. `DefaultErrorHandler`가 처리
   - `ExponentialBackOff`로 재시도 (1초 → 2초 → 4초 → 8초)
3. 계속 실패하면 `handleError` 실행
   - 실패 상태 WebSocket 전송
   
   - S3 멀티파트 업로드 중단
   - Redis 키 정리
   - 실패한 파일 ID 기록
4. 이후 동일 파일의 청크들은 스킵
5. 다른 파일의 청크는 정상 처리


close #59 